### PR TITLE
Add cancel goal for Action Client

### DIFF
--- a/include/cmr_tests_utils/basic_action_client_test.hpp
+++ b/include/cmr_tests_utils/basic_action_client_test.hpp
@@ -71,6 +71,19 @@ class BasicActionClientTest {
     return result_code_future.get().code;
   }
 
+  void cancel_goal() 
+  {
+    auto future_cancel = action_client_->async_cancel_goal(action_goal_handle_);
+    if (rclcpp::spin_until_future_complete(this->client_node_, future_cancel) !=
+      rclcpp::FutureReturnCode::SUCCESS)
+    {
+      RCLCPP_ERROR(rclcpp::get_logger(client_node_name_), "Failed to cancel action.");
+      return;
+    }
+
+    RCLCPP_INFO(rclcpp::get_logger(client_node_name_), "Successfully requested to cancel goal.");
+  }
+
   private:
 
   typename rclcpp_action::Client<ActionT>::SharedPtr action_client_;


### PR DESCRIPTION
## Purpose
To... cancel goals ?

## Approach
Well... it adds a... cancel... hum.. goal function that.. hum.. cancels the goal ?

## Disclaimers

 - I am very tempted to move the templated Action Client/Service Client to a separate repo, since imo it has much more usage than just testing. Anyone could need a client at some point, anywhere, not just for testing.