### PR TITLE
Timer instead of Thread

### DIFF
--- a/include/cmr_tests_utils/basic_subscriber_node_test.hpp
+++ b/include/cmr_tests_utils/basic_subscriber_node_test.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <mutex>
-
 #include <rclcpp/rclcpp.hpp>
 
 namespace cmr_tests_utils
@@ -32,41 +30,31 @@ class BasicSubscriberNodeTest: public rclcpp::Node {
     topic_info_ = std::make_shared<TopicInfo>();
     topic_info_->topic_name = topic_name;
 
-    timestamp_check_thread_ = std::thread(&BasicSubscriberNodeTest::update_liveness_, this);
-  }
-
-  ~BasicSubscriberNodeTest()
-  {
-    is_program_running_.store(false);
-    if (timestamp_check_thread_.joinable()) timestamp_check_thread_.join();
+    this->create_wall_timer(std::chrono::milliseconds(2000), std::bind(&BasicSubscriberNodeTest::update_liveness_, this));
   }
 
   std::shared_ptr<TopicInfo> get_topic_info() const
   {
-    std::lock_guard<std::mutex> lock(topic_info_mutex_);
     return topic_info_;
   }
 
   bool get_liveness() const 
   {
-    return is_alive_.load();
+    return is_alive_;
   }
 
   double get_frequency() const
   {
-    std::lock_guard<std::mutex> lock(frequency_mutex_);
     return frequency_;
   }
 
   bool has_data_been_received() const 
   {
-    std::lock_guard<std::mutex> lock(msg_mutex_);
     return (received_msg_ != nullptr);
   }
 
   MessageT get_received_msg() const
   {
-    std::lock_guard<std::mutex> lock(msg_mutex_);
     MessageT msg;
     if (!received_msg_) 
     {
@@ -82,12 +70,9 @@ class BasicSubscriberNodeTest: public rclcpp::Node {
 
   void topic_callback(const std::shared_ptr<MessageT> msg) 
   {  
-    is_alive_.store(true);
-
-    { 
-      std::lock_guard<std::mutex> lock(topic_info_mutex_);
-      topic_info_->is_alive = true;
-    }
+    is_alive_ = true;
+    topic_info_->is_alive = true;
+    
 
     if (!last_message_timestamp_)
     {
@@ -98,65 +83,38 @@ class BasicSubscriberNodeTest: public rclcpp::Node {
       auto now = std::chrono::system_clock::now();
       std::chrono::duration<double> elapsed_seconds = now - *last_message_timestamp_;
       double elapsec_seconds_double = elapsed_seconds.count();
-      { 
-        std::lock_guard<std::mutex> lock(frequency_mutex_);
-        frequency_ = 1 / elapsec_seconds_double;
-      }
+
+      frequency_ = 1 / elapsec_seconds_double;
       
-      {
-        std::lock_guard<std::mutex> lock(topic_info_mutex_);
-        topic_info_->frequency = 1 / elapsec_seconds_double;
-      }
+      topic_info_->frequency = 1 / elapsec_seconds_double;
       *last_message_timestamp_ = now;
     }
 
-    std::lock_guard<std::mutex> lock(msg_mutex_);
     received_msg_ = msg;
   }
 
   void update_liveness_() 
   {
-    std::chrono::duration<double> elapsed_seconds;
-    is_program_running_.store(true);
-    while (is_program_running_.load())
+    if (!last_message_timestamp_) return;
+
+    auto elapsed_seconds = std::chrono::system_clock::now() - *last_message_timestamp_;
+    
+    if (elapsed_seconds.count() > liveness_timeout_sec_) 
     {
-      {
-        std::lock_guard<std::mutex> lock(timestamp_mutex_);
-        if (!last_message_timestamp_) continue;
-
-        auto now = std::chrono::system_clock::now();
-        elapsed_seconds = now - *last_message_timestamp_;
-      }
-
-      if (elapsed_seconds.count() > liveness_timeout_sec_) 
-      {
-        is_alive_.store(false);
-        {
-          std::lock_guard<std::mutex> lock(topic_info_mutex_);
-          topic_info_->is_alive = false;
-          topic_info_->frequency = 0.0;
-        }
-      }
-      std::this_thread::sleep_for(std::chrono::seconds(2));
+      is_alive_ = false;
+      topic_info_->is_alive = false;
+      topic_info_->frequency = 0.0;
     }
   }
 
   typename rclcpp::Subscription<MessageT>::SharedPtr topic_sub_;
 
   std::shared_ptr<MessageT> received_msg_;
-  std::atomic<bool> is_alive_;
+  bool is_alive_;
   std::shared_ptr<std::chrono::time_point<std::chrono::system_clock>> last_message_timestamp_;
   double frequency_;
   double liveness_timeout_sec_;
   std::shared_ptr<TopicInfo> topic_info_;
-
-  std::thread timestamp_check_thread_;
-  
-  std::atomic<bool> is_program_running_;
-  mutable std::mutex msg_mutex_;
-  mutable std::mutex frequency_mutex_;
-  mutable std::mutex topic_info_mutex_;
-  mutable std::mutex timestamp_mutex_;
 };
 
 }


### PR DESCRIPTION
We may use an infinite number of instances for a SubscriberNode. CPU usage explodes quickly. No likey. Fixey.

When using 8 instances CPU usage went from 400% to 25%