### PR TITLE
move test dependency where it belongs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,6 @@ find_package(rclcpp_lifecycle REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
-find_package(example_interfaces REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(tf2 REQUIRED)
@@ -34,7 +33,6 @@ include_directories(include
   ${lifecycle_msgs_INCLUDE_DIRS}
   ${rclcpp_INCLUDE_DIRS}
   ${rclcpp_action_INCLUDE_DIRS}
-  ${example_interfaces_INCLUDE_DIRS}
   ${geometry_msgs_INCLUDE_DIRS}
   ${tf2_ros_INCLUDE_DIRS}
   ${tf2_INCLUDE_DIRS}
@@ -56,7 +54,6 @@ target_link_libraries(${LIBRARY_NAME} INTERFACE
   ${lifecycle_msgs_LIBRARIES}
   ${rclcpp_LIBRARIES}
   ${rclcpp_action_LIBRARIES}
-  ${example_interfaces_LIBRARIES}
   ${geometry_msgs_LIBRARIES}
   ${tf2_ros_LIBRARIES}
   ${tf2_geometry_msgs_LIBRARIES}
@@ -81,7 +78,6 @@ set(dependencies
   "lifecycle_msgs"
   "rclcpp"
   "rclcpp_action"
-  "example_interfaces"
   "geometry_msgs"
   "tf2_ros"
   "tf2"
@@ -92,6 +88,7 @@ set(dependencies
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
+  find_package(example_interfaces REQUIRED)
   add_subdirectory(test)
 endif()
 


### PR DESCRIPTION
## Purpose
`example_interfaces` package is used only in tests. This dependency is `<test_depend>example_interfaces</test_depend>` in `package.xml`, but was required in `CMakeLists.txt`.

## Approach
I moved `example_interfaces` to `if(BUILD_TESTING)` section, so if we build with flag `-DBUILD_TESTING=OFF` (release), it will not be required.

### Blog Posts
- [How to Pull Request](https://github.com/flexyford/pull-request) Github Repo with Learning focused Pull Request Template.