### PR TITLE
Refacto/cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
-find_package(lifecycle_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -29,7 +28,6 @@ find_package(nav_msgs REQUIRED)
 
 set(dependencies
   "rclcpp_lifecycle"
-  "lifecycle_msgs"
   "rclcpp"
   "rclcpp_action"
   "geometry_msgs"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,17 @@ find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 
+set(dependencies
+  "rclcpp_lifecycle"
+  "lifecycle_msgs"
+  "rclcpp"
+  "rclcpp_action"
+  "geometry_msgs"
+  "tf2_ros"
+  "tf2"
+  "tf2_geometry_msgs"
+  "nav_msgs"
+)
 
 include_directories(include)
 
@@ -40,15 +51,7 @@ target_include_directories(${LIBRARY_NAME} INTERFACE
 )
 
 ament_target_dependencies(${LIBRARY_NAME} INTERFACE
-  rclcpp_lifecycle
-  lifecycle_msgs
-  rclcpp
-  rclcpp_action
-  geometry_msgs
-  tf2_ros
-  tf2_geometry_msgs
-  nav_msgs
-  tf2
+  ${dependencies}
 )
 
 install(TARGETS ${LIBRARY_NAME}
@@ -61,18 +64,6 @@ install(TARGETS ${LIBRARY_NAME}
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION include/${PROJECT_NAME}
-)
-
-set(dependencies
-  "rclcpp_lifecycle"
-  "lifecycle_msgs"
-  "rclcpp"
-  "rclcpp_action"
-  "geometry_msgs"
-  "tf2_ros"
-  "tf2"
-  "tf2_geometry_msgs"
-  "nav_msgs"
 )
 
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,17 +28,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 
 
-include_directories(include
-  ${rclcpp_lifecycle_INCLUDE_DIRS}
-  ${lifecycle_msgs_INCLUDE_DIRS}
-  ${rclcpp_INCLUDE_DIRS}
-  ${rclcpp_action_INCLUDE_DIRS}
-  ${geometry_msgs_INCLUDE_DIRS}
-  ${tf2_ros_INCLUDE_DIRS}
-  ${tf2_INCLUDE_DIRS}
-  ${tf2_geometry_msgs_INCLUDE_DIRS}
-  ${nav_msgs_INCLUDE_DIRS}
-)
+include_directories(include)
 
 set(LIBRARY_NAME "${PROJECT_NAME}_lib")
 
@@ -49,16 +39,16 @@ target_include_directories(${LIBRARY_NAME} INTERFACE
   $<INSTALL_INTERFACE:include>
 )
 
-target_link_libraries(${LIBRARY_NAME} INTERFACE
-  ${rclcpp_lifecycle_LIBRARIES}
-  ${lifecycle_msgs_LIBRARIES}
-  ${rclcpp_LIBRARIES}
-  ${rclcpp_action_LIBRARIES}
-  ${geometry_msgs_LIBRARIES}
-  ${tf2_ros_LIBRARIES}
-  ${tf2_geometry_msgs_LIBRARIES}
-  ${nav_msgs_LIBRARIES}
-  ${tf2_LIBRARIES}
+ament_target_dependencies(${LIBRARY_NAME} INTERFACE
+  rclcpp_lifecycle
+  lifecycle_msgs
+  rclcpp
+  rclcpp_action
+  geometry_msgs
+  tf2_ros
+  tf2_geometry_msgs
+  nav_msgs
+  tf2
 )
 
 install(TARGETS ${LIBRARY_NAME}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(dependencies
-  ${dependencies}
   "cmr_clients_utils"
   "example_interfaces"
 )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(dependencies
   ${dependencies}
   "cmr_clients_utils"
+  "example_interfaces"
 )
 
 find_package(cmr_clients_utils REQUIRED)


### PR DESCRIPTION
## Purpose
In https://github.com/cmrobotics/cmr_tests_utils/pull/15 I moved one dependency used only for testing to `if(BUILD_TESTING)` section, but this excluded it from becoming a target in parent cmake. This broke build. I'm fixing it with first commit and introducing some refactoring to use modern style cmake.

Of course, this time, I tested clean build with all configurations that we use.

### Blog Posts
- [How to Pull Request](https://github.com/flexyford/pull-request) Github Repo with Learning focused Pull Request Template.